### PR TITLE
Fix uniq output flag

### DIFF
--- a/src/freva/cli/plugin.py
+++ b/src/freva/cli/plugin.py
@@ -92,7 +92,8 @@ class Cli(BaseParser):
         )
         self.parser.add_argument(
             "--unique-output",
-            choices=["true", "false"],
+            "--unique_output",
+            choices=["true", "false", "True", "False"],
             help="Append a Freva run id to the output/cache folder(s).",
             default="true",
         )


### PR DESCRIPTION
This fixes the problem that the freva-plugin cmd dies after it is submitted via `--unique-output True`