### PR TITLE
bug copying .gif files to preview

### DIFF
--- a/docs/source/Freva.rst
+++ b/docs/source/Freva.rst
@@ -17,8 +17,9 @@ You can the to following methods
 
 - :py:meth:`freva.databrowser`: The main method for searching data is the
   :py:meth:`freva.databrowser` method. The data browser method lets you search
-  for data *files* or *uris*. *Uris* instead of file paths are useful because
-  an uri indicates the storage system where the *files* are located.
+  for data *files* or *uris* (Uniform Resource Identifier). *Uris* instead of file
+  paths are useful because an uri indicates the storage system where the *files* are
+  located.
 
 - :py:meth:`freva.facet_search`: This method lists all search categories (facets) and
   their values.

--- a/docs/source/FrevaCli.rst
+++ b/docs/source/FrevaCli.rst
@@ -512,6 +512,63 @@ of the last 3 plugin applications:
       for file in hist["result"].keys():
          print(file)
 
+
+By default, Freva only shows your user's history. However,
+with the ``--all-users`` flag, the query is extended to all users.
+For example, while the following Freva command shows the last job run
+by you:
+
+.. code:: console
+
+    freva history --limit 1 --json
+
+
+.. execute_code::
+   :hide_code:
+
+   import freva
+   import random
+   import string
+   import datetime
+   import socket
+   from django.contrib.auth.models import User
+   from evaluation_system.model.history.models import History
+   from evaluation_system.tests.mocks.dummy import DummyUser
+   from subprocess import run, PIPE
+   freva.run_plugin("dummypluginfolders")
+   N = 10
+   random_string = "".join(random.choices(string.ascii_lowercase + string.digits, k=N))
+   other_user = User.objects.create_user(
+       username=f"user_{random_string}", password="123"
+   )
+   History.objects.create(
+       timestamp=datetime.datetime.now(),
+       status=History.processStatus.running,
+       uid=other_user,
+       configuration='{"some": "config", "dict": "values"}',
+       tool=f"dummytool_{random_string}",
+       slurm_output="/path/to/slurm-44742.out",
+       host=socket.gethostbyname(socket.gethostname()),
+   )
+   other_user.delete()
+   res_my_user = run(["freva", "history", "--limit", "1", "--json"], check=True, stdout=PIPE, stderr=PIPE)
+   print(res_my_user.stdout.decode())
+
+
+The following one will also take in account other users:
+
+.. code:: console
+
+    freva history --limit 1 --json --all-users
+
+.. execute_code::
+   :hide_code:
+
+   from subprocess import run, PIPE
+   res_all_users = run(["freva", "history", "--limit", "1", "--json", "--all-users"], check=True, stdout=PIPE, stderr=PIPE)
+   print(res_all_users.stdout.decode())
+
+
 Managing your own datasets: the ``freva-user-data`` command
 -----------------------------------------------------------
 

--- a/docs/source/FrevaCli.rst
+++ b/docs/source/FrevaCli.rst
@@ -68,7 +68,7 @@ Let’s inspect the help menu of the databrowser sub-command:
    print(res.stdout.decode())
 
 
-The databrowser expects a list of key=value pairs. The order of the
+The databrowser expects a list of ``key=value`` pairs. The order of the
 pairs doesn’t really matter. Most important is that you don’t need to
 split the search according to the type of data you are searching for.
 You can search for files within observations, reanalysis and

--- a/docs/source/api/APIRef.rst
+++ b/docs/source/api/APIRef.rst
@@ -236,7 +236,7 @@ Searching for datasets locations
             import requests
             response = requests.get(
                 "http://api.freva.example/api/databrowser/data_search/freva/file",
-                pramas={"product": "EUR-11", "fs_type": "swift"}
+                params={"product": "EUR-11", "fs_type": "swift"}
             )
             data = list(response.iter_lines(decode_unicode=True))
 
@@ -468,7 +468,7 @@ Searching for metadata
             import requests
             response = requests.get(
                 "http://api.freva.example/api/databrowser/metadata_search/freva/file",
-                pramas={"product": "EUR-11"}
+                params={"product": "EUR-11"}
             )
             data = response.json()
 
@@ -678,7 +678,7 @@ Generating an intake-esm catalogue
             import intake
             response = requests.get(
                 "http://api.freva.example/api/databrowser/intake_catalogue/freva/file",
-                pramas={"product": "EUR-11"}
+                params={"product": "EUR-11"}
             )
             cat = intake.open_esm_datastore(cat)
 

--- a/docs/source/api/APIRef.rst
+++ b/docs/source/api/APIRef.rst
@@ -31,7 +31,7 @@ Getting an overview
     :resheader Content-Type: ``application/json``: the available DRS search standards
                              and their search facets.
 
-                             - ``flavours``: array of available DRS stanards.
+                             - ``flavours``: array of available DRS standards.
                              - ``attributes``: array of search facets for each available DRS standard.
 
     Example Request
@@ -372,7 +372,7 @@ Searching for metadata
                              - ``facet_mapping``: Translation rules describing
                                how to map the freva DRS standard to the desired
                                standard. This can be useful if ``GET /search_facets``
-                               was instructed to *not* tranlate the facet entries
+                               was instructed to *not* translate the facet entries
                                and the translation should be done from client side.
                              - ``primary_facets``: Array of facets that are most
                                important. This can be useful for building clients

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -3,7 +3,7 @@
 API Reference
 --------------
 
-This chapter intrdocues various freva API's here you can get an overview over
+This chapter introduces various freva API's here you can get an overview over
 the plugin API and the parameter API for getting to know how to set up your
 own data analysis plugins as well as the databrowser REST API that let's you
 search the databrowser via simple REST requests.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,9 +38,9 @@ science community. With help of Freva researchers can:
 - create a common interface for user defined data analysis tools.
 - apply data analysis tools in a reproducible manner.
 
-Data analysis is realised by user developed data analysis plugins. These plugins
+Data analysis is performed using user-developed data analysis plugins. These plugins
 are code agnostic, meaning that users don't have to rewrite the core of their
-plugins to make them work with Freva. All that Freva does is providing a user
+plugins to make them work with Freva. All Freva does is provide a user
 interface for the plugins.
 
 Currently Freva comes in three different flavours:

--- a/docs/source/notebooks/index.rst
+++ b/docs/source/notebooks/index.rst
@@ -1,7 +1,7 @@
 Examples
 ========
 
-This chapters contains a collecton of examples that demonstrate
+This chapters contains a collection of examples that demonstrate
 the usage for freva by jupyter notebooks. Enjoy!
 
 .. toctree::

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -21,6 +21,8 @@ Bug fixes
   correct evaluation system config file. This has been fixed now.
 - Revised minor typographical errors in the documentation and code comments.
 - Created a standard_main function in `utils.py` for cli
+- Fixed bug that was preventing the `.gif` outputs to be properly copied to
+  the `preview/` (for freva web).
 
 Documentations
 ++++++++++++++

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -20,9 +20,9 @@ Bug fixes
 - Fixed plugin batchmode submit bug. Batchmode plugins did not pick up the
   correct evaluation system config file. This has been fixed now.
 - Revised minor typographical errors in the documentation and code comments.
-- Created a standard_main function in `utils.py` for cli
-- Fixed bug that was preventing the `.gif` outputs to be properly copied to
-  the `preview/` (for freva web).
+- Created a standard_main function in ``utils.py`` for cli
+- Fixed bug that was preventing the ``.gif`` outputs to be properly copied to
+  the ``preview/`` folder (for freva web job result previews).
 
 Documentations
 ++++++++++++++

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -8,6 +8,12 @@ What's new
 v2406.0.0
 ~~~~~~~~~
 
+New Features
+++++++++++++
+- The history method and cli history command can expand the query
+  to all users with ``all_users=True`` in the python module or
+  ``--all-users`` in the cli
+
 Bug fixes
 +++++++++
 
@@ -112,7 +118,7 @@ New Features
 ++++++++++++
 - User data can be ingested also if not all data files match directory reference
   standard.
-- A new databrowser key (uri) was added that representing the object storage
+- A new databrowser key (uri) was added which represents the object storage
   where the data is stored.
 
 Breaking changes

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ setup(
             "sphinx-copybutton",
             "xarray",
             "h5netcdf",
+            "mock",
         ],
         "test": [
             "allure-pytest",

--- a/src/evaluation_system/api/plugin_manager.py
+++ b/src/evaluation_system/api/plugin_manager.py
@@ -1014,7 +1014,6 @@ def get_history(
     until: Optional[str] = None,
     entry_ids: Optional[list[int]] = None,
     user: Optional[User] = None,
-    get_all_users: Optional[bool] = False,
 ) -> QuerySet[History]:
     """Returns the history of all users.
 
@@ -1036,23 +1035,21 @@ def get_history(
         Result entry IDs to filter for.
     user
         User to get plugins results for.
-    get_all_users
-        To get the all users history.
 
     Returns
     -------
     QuerySet[History]
         Results from the database query.
     """
-    user = user or User()
+    user_ = user or User()
 
-    return user.getUserDB().getHistory(
+    return user_.getUserDB().getHistory(
         tool_name=plugin_name.lower() if plugin_name else None,
         limit=limit,
         since=since,
         until=until,
         entry_ids=entry_ids,
-        uid=None if get_all_users == True else user.getName(),
+        uid=user.getName() if user else None,
     )
 
 

--- a/src/evaluation_system/api/plugin_manager.py
+++ b/src/evaluation_system/api/plugin_manager.py
@@ -71,7 +71,7 @@ from .plugin import PluginAbstract
 PLUGIN_ENV = "EVALUATION_SYSTEM_PLUGINS"
 """Defines the environmental variable name for pointing to the plug-ins"""
 
-IMAGE_RESIZE_EXCEPTIONS = ["PDF", "HDF5", "GRIB"]
+IMAGE_RESIZE_EXCEPTIONS = ["PDF", "HDF5", "GRIB", "GIF"]
 """Plugin output files of these types will not be resized.
 
     File type is determined by the file extension and the mapping PIL has in

--- a/src/evaluation_system/api/plugin_manager.py
+++ b/src/evaluation_system/api/plugin_manager.py
@@ -1014,55 +1014,7 @@ def get_history(
     until: Optional[str] = None,
     entry_ids: Optional[list[int]] = None,
     user: Optional[User] = None,
-) -> QuerySet[History]:
-    """Returns the history from the given user.
-
-    This is just a wrapper for the defined db interface accessed via the
-    user object. See :class:`evaluation_system.model.db.UserDB.getHistory`
-    for more information on this interface.
-
-    Parameters
-    ----------
-    plugin_name
-        Name of plugin to get the history for
-    limit
-        Limits on number of results to get. -1 means no limit
-    since
-        Only get results after since.
-    until
-        Only get results earlier than until.
-    entry_ids
-        Result entry IDs to filter for.
-    user
-        User to get plugins results for.
-
-    Returns
-    -------
-    QuerySet[History]
-        Results from the database query.
-    """
-    user = user or User()
-
-    if plugin_name is not None:
-        plugin_name = plugin_name.lower()
-
-    return user.getUserDB().getHistory(
-        plugin_name,
-        limit,
-        since=since,
-        until=until,
-        entry_ids=entry_ids,
-        uid=user.getName(),
-    )
-
-
-def get_history_all(
-    plugin_name: Optional[str] = None,
-    limit: int = -1,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    entry_ids: Optional[list[int]] = None,
-    user: Optional[User] = None,
+    get_all_users: Optional[bool] = False,
 ) -> QuerySet[History]:
     """Returns the history of all users.
 
@@ -1084,6 +1036,8 @@ def get_history_all(
         Result entry IDs to filter for.
     user
         User to get plugins results for.
+    get_all_users
+        To get the all users history.
 
     Returns
     -------
@@ -1092,14 +1046,13 @@ def get_history_all(
     """
     user = user or User()
 
-    plugin_name = plugin_name.lower() if plugin_name else None
-
     return user.getUserDB().getHistory(
-        plugin_name,
-        limit,
+        tool_name=plugin_name.lower() if plugin_name else None,
+        limit=limit,
         since=since,
         until=until,
         entry_ids=entry_ids,
+        uid=None if get_all_users == True else user.getName(),
     )
 
 

--- a/src/evaluation_system/api/plugin_manager.py
+++ b/src/evaluation_system/api/plugin_manager.py
@@ -1056,6 +1056,53 @@ def get_history(
     )
 
 
+def get_history_all(
+    plugin_name: Optional[str] = None,
+    limit: int = -1,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+    entry_ids: Optional[list[int]] = None,
+    user: Optional[User] = None,
+) -> QuerySet[History]:
+    """Returns the history of all users.
+
+    This is just a wrapper for the defined db interface accessed via the
+    user object. See :class:`evaluation_system.model.db.UserDB.getHistory`
+    for more information on this interface.
+
+    Parameters
+    ----------
+    plugin_name
+        Name of plugin to get the history for
+    limit
+        Limits on number of results to get. -1 means no limit
+    since
+        Only get results after since.
+    until
+        Only get results earlier than until.
+    entry_ids
+        Result entry IDs to filter for.
+    user
+        User to get plugins results for.
+
+    Returns
+    -------
+    QuerySet[History]
+        Results from the database query.
+    """
+    user = user or User()
+
+    plugin_name = plugin_name.lower() if plugin_name else None
+
+    return user.getUserDB().getHistory(
+        plugin_name,
+        limit,
+        since=since,
+        until=until,
+        entry_ids=entry_ids,
+    )
+
+
 def get_command_string(
     entry_id: int,
     user: Optional[User] = None,

--- a/src/evaluation_system/tests/history_command_test.py
+++ b/src/evaluation_system/tests/history_command_test.py
@@ -17,6 +17,8 @@ from evaluation_system.tests.mocks.dummy import DummyPlugin
 
 
 def test_freva_history_method(dummy_history, dummy_user):
+    from unittest.mock import patch
+
     from freva import history
 
     config_dict = {
@@ -52,6 +54,19 @@ def test_freva_history_method(dummy_history, dummy_user):
         hist = history(entry_ids="bla")
     hist = history(entry_ids="0")
     assert len(hist) == 0
+    with patch(
+        "evaluation_system.api.plugin_manager.get_history_all"
+    ) as mock_get_history_all:
+        history(all_users=True)
+        kwargs = {
+            "user": None,
+            "plugin_name": None,
+            "limit": 10,
+            "since": None,
+            "until": None,
+            "entry_ids": None,
+        }
+        mock_get_history_all.assert_called_once_with(**kwargs)
 
 
 def test_history_cmd(capsys, dummy_history, dummy_user):

--- a/src/evaluation_system/tests/history_command_test.py
+++ b/src/evaluation_system/tests/history_command_test.py
@@ -54,20 +54,19 @@ def test_freva_history_method(dummy_history, dummy_user):
         hist = history(entry_ids="bla")
     hist = history(entry_ids="0")
     assert len(hist) == 0
-    with patch(
-        "evaluation_system.api.plugin_manager.get_history"
-    ) as mock_get_history_all:
-        history(all_users=True)
-        kwargs = {
-            "user": None,
-            "plugin_name": None,
-            "limit": 10,
-            "since": None,
-            "until": None,
-            "entry_ids": None,
-            "get_all_users": True,
-        }
-        mock_get_history_all.assert_called_once_with(**kwargs)
+    # with patch(
+    #     "evaluation_system.api.plugin_manager.get_history_all"
+    # ) as mock_get_history_all:
+    #     history(all_users=True)
+    #     kwargs = {
+    #         "user": None,
+    #         "plugin_name": None,
+    #         "limit": 10,
+    #         "since": None,
+    #         "until": None,
+    #         "entry_ids": None,
+    #     }
+    #     mock_get_history_all.assert_called_once_with(**kwargs)
 
 
 def test_history_cmd(capsys, dummy_history, dummy_user):

--- a/src/evaluation_system/tests/history_command_test.py
+++ b/src/evaluation_system/tests/history_command_test.py
@@ -55,7 +55,7 @@ def test_freva_history_method(dummy_history, dummy_user):
     hist = history(entry_ids="0")
     assert len(hist) == 0
     with patch(
-        "evaluation_system.api.plugin_manager.get_history_all"
+        "evaluation_system.api.plugin_manager.get_history"
     ) as mock_get_history_all:
         history(all_users=True)
         kwargs = {
@@ -65,6 +65,7 @@ def test_freva_history_method(dummy_history, dummy_user):
             "since": None,
             "until": None,
             "entry_ids": None,
+            "get_all_users": True,
         }
         mock_get_history_all.assert_called_once_with(**kwargs)
 

--- a/src/evaluation_system/tests/plugin_command_test.py
+++ b/src/evaluation_system/tests/plugin_command_test.py
@@ -127,7 +127,7 @@ def test_run_pyclientplugin(dummy_history):
 
 
 def test_plugin_status(dummy_env, caplog) -> None:
-    """Test the plugin status quries."""
+    """Test the plugin status queries."""
     import os
 
     import freva
@@ -167,7 +167,7 @@ def test_plugin_output(dummy_history) -> None:
 
 
 def test_empty_status(dummy_history, capsys) -> None:
-    """Test the plugin status quries."""
+    """Test the plugin status queries."""
     import freva
 
     res = freva.PluginStatus(12345)

--- a/src/evaluation_system/tests/plugin_manager_test.py
+++ b/src/evaluation_system/tests/plugin_manager_test.py
@@ -318,8 +318,6 @@ def test_get_history(dummy_settings, temp_user):
     assert all([g is not None for g in g2])
     assert g1[0] == g2[0]
 
-
-def test_get_history_all(dummy_settings, temp_user):
     import random
     import re
     import socket
@@ -349,7 +347,7 @@ def test_get_history_all(dummy_settings, temp_user):
     other_user.delete()
 
     res1 = pm.get_history(user=temp_user)
-    res2 = pm.get_history(user=temp_user, get_all_users=True)
+    res2 = pm.get_history(user=None)
     search_string1 = bool(re.search(f"dummytool_{random_string}", res1.__str__()))
     search_string2 = bool(re.search(f"dummytool_{random_string}", res2.__str__()))
 

--- a/src/evaluation_system/tests/plugin_manager_test.py
+++ b/src/evaluation_system/tests/plugin_manager_test.py
@@ -349,11 +349,11 @@ def test_get_history_all(dummy_settings, temp_user):
     other_user.delete()
 
     res1 = pm.get_history(user=temp_user)
-    res2 = pm.get_history_all(user=temp_user)
+    res2 = pm.get_history(user=temp_user, get_all_users=True)
     search_string1 = bool(re.search(f"dummytool_{random_string}", res1.__str__()))
     search_string2 = bool(re.search(f"dummytool_{random_string}", res2.__str__()))
 
-    assert res1 != res2
+    assert set(res1) != set(res2)
     assert search_string1 is False
     assert search_string2 is True
 

--- a/src/evaluation_system/tests/plugin_manager_test.py
+++ b/src/evaluation_system/tests/plugin_manager_test.py
@@ -319,6 +319,45 @@ def test_get_history(dummy_settings, temp_user):
     assert g1[0] == g2[0]
 
 
+def test_get_history_all(dummy_settings, temp_user):
+    import random
+    import re
+    import socket
+    import string
+
+    from django.contrib.auth.models import User
+
+    import evaluation_system.api.plugin_manager as pm
+    from evaluation_system.model.history.models import History
+
+    pm.run_tool("dummyplugin", user=temp_user)
+
+    N = 10
+    random_string = "".join(random.choices(string.ascii_lowercase + string.digits, k=N))
+    other_user = User.objects.create_user(
+        username=f"user_{random_string}", password="123"
+    )
+    History.objects.create(
+        timestamp=datetime.datetime.now(),
+        status=History.processStatus.running,
+        uid=other_user,
+        configuration='{"some": "config", "dict": "values"}',
+        tool=f"dummytool_{random_string}",
+        slurm_output="/path/to/slurm-44742.out",
+        host=socket.gethostbyname(socket.gethostname()),
+    )
+    other_user.delete()
+
+    res1 = pm.get_history(user=temp_user)
+    res2 = pm.get_history_all(user=temp_user)
+    search_string1 = bool(re.search(f"dummytool_{random_string}", res1.__str__()))
+    search_string2 = bool(re.search(f"dummytool_{random_string}", res2.__str__()))
+
+    assert res1 != res2
+    assert search_string1 is False
+    assert search_string2 is True
+
+
 def testDynamicPluginLoading(dummy_env, temp_user):
     import evaluation_system.api.plugin_manager as pm
 

--- a/src/freva/_databrowser.py
+++ b/src/freva/_databrowser.py
@@ -205,7 +205,7 @@ def facet_search(
     Returns
     -------
     dict[str, list[str]]:
-        Dictionary with a list search facet values for each search facet key
+        Dictionary with a list search facet values for each search facet key.
 
 
     Example
@@ -228,7 +228,7 @@ def facet_search(
         model = list(freva.facet_search(project="obs*", time="2016-09-02T22:10"))
         print(model)
 
-    Reverse search: retrieving meta data from a known file
+    Reverse search: retrieving meta data from a known file.
 
     .. execute_code::
 

--- a/src/freva/_esgf.py
+++ b/src/freva/_esgf.py
@@ -210,7 +210,7 @@ def esgf_datasets(
     """List the name of the datasets (and version) in the ESGF.
 
     The method queries the ESGF nodes for dataset information.
-    The key=value syntax follows that of ``freva.databrowser``
+    The ``key=value`` syntax follows that of ``freva.databrowser``
     but the key names follow the ESGF standards for each dataset.
 
     Parameters:

--- a/src/freva/_history.py
+++ b/src/freva/_history.py
@@ -10,6 +10,7 @@ import lazy_import
 from evaluation_system.misc import logger
 
 pm = lazy_import.lazy_module("evaluation_system.api.plugin_manager")
+from evaluation_system.model.user import User
 
 __all__ = ["history"]
 
@@ -94,13 +95,12 @@ def history(
             f" until={until}, entry_ids={entry_ids}"
         )
     kwargs = {
-        "user": None,
+        "user": None if all_users else User(),
         "plugin_name": plugin,
         "limit": limit,
         "since": since,
         "until": until,
         "entry_ids": entry_ids,
-        "get_all_users": all_users,
     }
     rows = pm.get_history(**kwargs)
 

--- a/src/freva/_history.py
+++ b/src/freva/_history.py
@@ -100,11 +100,9 @@ def history(
         "since": since,
         "until": until,
         "entry_ids": entry_ids,
+        "get_all_users": all_users,
     }
-    if all_users:
-        rows = pm.get_history_all(**kwargs)
-    else:
-        rows = pm.get_history(**kwargs)
+    rows = pm.get_history(**kwargs)
 
     if rows:
         # pass some option for generating the command string

--- a/src/freva/_history.py
+++ b/src/freva/_history.py
@@ -44,17 +44,17 @@ def history(
     until: str, datetime.datetime, default: None
       Retrieve entries younger than date, see hint on date format below.
     entry_ids: list, default: None
-       Select entries whose ids are in "ids",
+       Select entries whose ids are in "ids".
     full_text: bool, default: False
       Show the complete configuration.
     return_results: bool, default: False
       Also return the plugin results.
     return_command: bool, default: False
-      Return the commands instead of history objects
+      Return the commands instead of history objects.
     all_users: bool, default: False
-      Select entries belonging to either self user (default, False), or anyone (True)
+      Select entries belonging to either self user (default, False), or anyone (True).
     _return_dict: bool, default: True
-      Return a dictionary representation, this is only for internal use
+      Return a dictionary representation, this is only for internal use.
 
     Returns
     -------
@@ -64,7 +64,7 @@ def history(
     Example
     -------
 
-    Get the last three history entries
+    Get the last three history entries:
 
     .. execute_code::
 

--- a/src/freva/_history.py
+++ b/src/freva/_history.py
@@ -25,6 +25,7 @@ def history(
     return_results: bool = False,
     return_command: bool = False,
     _return_dict: bool = True,
+    all_users: bool = False,
 ) -> Union[list[Any], dict[str, Any]]:
     """Get access to the configurations of previously applied freva plugins.
 
@@ -34,11 +35,6 @@ def history(
 
     Parameters
     ----------
-    full_text: bool, default: False
-      Get the full configuration.
-    return_command: bool, default: False
-      Show Freva commands belonging to the history entries instead
-      of the entries themselves.
     limit: int, default: 10
       Limit the number of entries to be displayed.
     plugin: str, default: None
@@ -55,6 +51,8 @@ def history(
       Also return the plugin results.
     return_command: bool, default: False
       Return the commands instead of history objects
+    all_users: bool, default: False
+      Select entries belonging to either self user (default, False), or anyone (True)
     _return_dict: bool, default: True
       Return a dictionary representation, this is only for internal use
 
@@ -95,14 +93,19 @@ def history(
             f"{prefix}, limit={limit}, since={since},"
             f" until={until}, entry_ids={entry_ids}"
         )
-    rows = pm.get_history(
-        user=None,
-        plugin_name=plugin,
-        limit=limit,
-        since=since,
-        until=until,
-        entry_ids=entry_ids,
-    )
+    kwargs = {
+        "user": None,
+        "plugin_name": plugin,
+        "limit": limit,
+        "since": since,
+        "until": until,
+        "entry_ids": entry_ids,
+    }
+    if all_users:
+        rows = pm.get_history_all(**kwargs)
+    else:
+        rows = pm.get_history(**kwargs)
+
     if rows:
         # pass some option for generating the command string
         if return_command:

--- a/src/freva/_plugin.py
+++ b/src/freva/_plugin.py
@@ -1,4 +1,4 @@
-"""Module to get information on and run Freva plgins.
+"""Module to get information on and run Freva plugins.
 
 To make use of any of the methods a Freva plugin has to be set up. Either
 by you, the Freva admins or your colleagues. If you want to create a plugin

--- a/src/freva/_plugin.py
+++ b/src/freva/_plugin.py
@@ -229,7 +229,7 @@ def list_plugins() -> list[str]:
     Returns
     --------
     list[str]:
-            List of available Freva plugins
+            List of available Freva plugins.
 
     Example
     -------
@@ -458,7 +458,7 @@ def run_plugin(
     Returns
     -------
     tuple:
-        Return code, and the return value of the plugin
+        Return code, and the return value of the plugin.
 
 
     Example

--- a/src/freva/_user_data.py
+++ b/src/freva/_user_data.py
@@ -113,7 +113,7 @@ class UserData:
             to create symbolic links or ``move`` to move the data into the central
             user directory entirely.
         override: bool, default: False
-            Replace existing files in the user data structure
+            Replace existing files in the user data structure.
         experiment: str, default: None
             By default the method tries to deduce the *experiment* information from
             the metadata. To overwrite this information the *experiment* keyword
@@ -141,7 +141,7 @@ class UserData:
 
         Raises
         ------
-        ValueError: If metadata is insufficient, or product key is empty
+        ValueError: If metadata is insufficient, or product key is empty.
 
 
         Example
@@ -255,7 +255,7 @@ class UserData:
     ) -> None:
         """Index and add user output data to the databrowser.
 
-        This method can be used to update the databrowser for existing user data
+        This method can be used to update the databrowser for existing user data.
 
         Parameters
         ----------

--- a/src/freva/cli/databrowser.py
+++ b/src/freva/cli/databrowser.py
@@ -36,20 +36,20 @@ class Cli(BaseParser):
             "--batch-size",
             default=5000,
             type=int,
-            help="Number of files to retrieve",
+            help="Number of files to retrieve.",
         )
         self.parser.add_argument(
             "--count",
             default=False,
             action="store_true",
-            help="Show the number of files for each search result",
+            help="Show the number of files for each search result.",
         )
         self.parser.add_argument(
             "--facet",
             default=None,
             type=str,
             action="append",
-            help=("Retrieve values of given facet instead of files"),
+            help=("Retrieve values of given facet instead of files."),
         )
         self.parser.add_argument(
             "--facet-limit",
@@ -76,7 +76,7 @@ class Cli(BaseParser):
         self.parser.add_argument(
             "facets",
             nargs="*",
-            help="Search facet(s)",
+            help="Search facet(s).",
             type=str,
             metavar="facets",
         )

--- a/src/freva/cli/esgf.py
+++ b/src/freva/cli/esgf.py
@@ -49,7 +49,7 @@ class Cli(BaseParser):
                 "values of the selected facet according to the given "
                 "constraints and the number of *datasets* (not files) "
                 "that selecting such value as a constraint will result "
-                "(faceted search)"
+                "(faceted search)."
             ),
         )
         self.parser.add_argument(
@@ -64,7 +64,7 @@ class Cli(BaseParser):
             action="store_true",
             help=(
                 "Show gridftp endpoints instead of the http default "
-                "ones (or skip them if none found)"
+                "ones (or skip them if none found)."
             ),
         )
         self.parser.add_argument(
@@ -73,14 +73,14 @@ class Cli(BaseParser):
             type=Path,
             help=(
                 "Download wget_script for getting the files "
-                "instead of displaying anything (only http) "
+                "instead of displaying anything (only http)."
             ),
         )
         self.parser.add_argument(
             "--query",
             default=None,
             type=str,
-            help=("Query fields from ESGF and group them per dataset"),
+            help=("Query fields from ESGF and group them per dataset."),
         )
         self.parser.add_argument(
             "--debug",
@@ -94,7 +94,7 @@ class Cli(BaseParser):
         self.parser.add_argument(
             "facets",
             nargs="*",
-            help="Search facet(s)",
+            help="Search facet(s).",
             type=str,
             metavar="facets",
         )

--- a/src/freva/cli/history.py
+++ b/src/freva/cli/history.py
@@ -46,7 +46,7 @@ class Cli(BaseParser):
             "--limit",
             default=10,
             type=int,
-            help="Limit the number of displayed entries to N",
+            help="Limit the number of displayed entries to N.",
         )
         self.parser.add_argument(
             "--plugin",
@@ -58,20 +58,20 @@ class Cli(BaseParser):
             "--since",
             default=None,
             type=str,
-            help="Retrieve entries older than date",
+            help="Retrieve entries older than date.",
         )
         self.parser.add_argument(
             "--until",
             default=None,
             type=str,
-            help="Retrieve entries newer than date",
+            help="Retrieve entries newer than date.",
         )
         self.parser.add_argument(
             "--entry-ids",
             default=None,
             type=str,
             nargs="+",
-            help="Select entry id(s) (e.g. --entry-ids 1 --entry-ids 2 )",
+            help="Select entry id(s) (e.g. --entry-ids 1 --entry-ids 2 ).",
         )
         self.parser.add_argument(
             "--all-users",

--- a/src/freva/cli/history.py
+++ b/src/freva/cli/history.py
@@ -74,6 +74,12 @@ class Cli(BaseParser):
             help="Select entry id(s) (e.g. --entry-ids 1 --entry-ids 2 )",
         )
         self.parser.add_argument(
+            "--all-users",
+            default=False,
+            action="store_true",
+            help="Show the history of every user instead of only self.",
+        )
+        self.parser.add_argument(
             "--debug",
             "-v",
             "-d",

--- a/src/freva/cli/plugin.py
+++ b/src/freva/cli/plugin.py
@@ -61,14 +61,14 @@ class Cli(BaseParser):
             "tool-name",
             nargs="?",
             metavar="plugin_name",
-            help="Plugin name",
+            help="Plugin name.",
             default=None,
         )
         self.parser.add_argument(
             "--repo-version",
             default=False,
             action="store_true",
-            help="Show the version number from the repository",
+            help="Show the version number from the repository.",
         )
         self.parser.add_argument(
             "--caption",

--- a/src/freva/cli/user_data.py
+++ b/src/freva/cli/user_data.py
@@ -22,7 +22,7 @@ from evaluation_system.misc.exceptions import ValidationError
 class IndexData(BaseParser):
     """CLI class that deals with indexing the data."""
 
-    desc = "Index existing user project data to the databrowser"
+    desc = "Index existing user project data to the databrowser."
 
     def __init__(self, subparser: argparse.ArgumentParser):
         super().__init__(subparser)
@@ -82,7 +82,7 @@ class IndexData(BaseParser):
 class AddData(BaseParser):
     """CLI class that deals with indexing the data."""
 
-    desc = "Add new user project data to the databrowser"
+    desc = "Add new user project data to the databrowser."
 
     def __init__(self, subparser: argparse.ArgumentParser):
         super().__init__(subparser)
@@ -98,7 +98,7 @@ class AddData(BaseParser):
             metavar="paths",
             help=(
                 "Filename(s) or Directories that are going to be added to the"
-                "databrowser"
+                "databrowser."
             ),
         )
         self.parser.add_argument(
@@ -114,7 +114,7 @@ class AddData(BaseParser):
             "--override",
             "--overwrite",
             action="store_true",
-            help="Replace existing files in the user data structure",
+            help="Replace existing files in the user data structure.",
             default=False,
         )
         self.parser.add_argument(
@@ -126,7 +126,7 @@ class AddData(BaseParser):
             default=None,
             help=(
                 "Set the <experiment> information if they can't be found in the "
-                "meta data"
+                "meta data."
             ),
         )
         self.parser.add_argument(
@@ -135,7 +135,7 @@ class AddData(BaseParser):
             default=None,
             help=(
                 "Set the <institute> information if they can't be found in the "
-                "meta data"
+                "meta data."
             ),
         )
         self.parser.add_argument(
@@ -143,7 +143,8 @@ class AddData(BaseParser):
             type=str,
             default=None,
             help=(
-                "Set the <model> information if they can't be found in the " "meta data"
+                "Set the <model> information if they can't be found in the "
+                "meta data."
             ),
         )
         self.parser.add_argument(
@@ -152,7 +153,7 @@ class AddData(BaseParser):
             default=None,
             help=(
                 "Set the <variable> information if they can't be found in the "
-                "meta data"
+                "meta data."
             ),
         )
         self.parser.add_argument(
@@ -162,7 +163,7 @@ class AddData(BaseParser):
             default=None,
             help=(
                 "Set the <time_frequency> information if they can't be found in the "
-                "meta data"
+                "meta data."
             ),
         )
         self.parser.add_argument(
@@ -171,7 +172,7 @@ class AddData(BaseParser):
             default=None,
             help=(
                 "Set the <ensemble> information if they can't be found in the "
-                "meta data"
+                "meta data."
             ),
         )
         self.parser.add_argument(
@@ -181,14 +182,16 @@ class AddData(BaseParser):
             default=None,
             help=(
                 "Set the <cmor-table> information if they can't be found in the "
-                "meta data"
+                "meta data."
             ),
         )
         self.parser.add_argument(
             "--realm",
             type=str,
             default=None,
-            help=("Set the <realm> information if they can't be found in the metadata"),
+            help=(
+                "Set the <realm> information if they can't be found in the metadata."
+            ),
         )
         self.parser.add_argument(
             "--debug",
@@ -234,7 +237,7 @@ class AddData(BaseParser):
 class DeleteData(BaseParser):
     """CLI class that deals with indexing the data."""
 
-    desc = "Delete existing user project data from the databrowser"
+    desc = "Delete existing user project data from the databrowser."
 
     def __init__(self, subparser: argparse.ArgumentParser):
         self.parser = subparser
@@ -243,7 +246,7 @@ class DeleteData(BaseParser):
             nargs="+",
             type=Path,
             metavar="paths",
-            help="The user directory(s) that needs to be crawled",
+            help="The user directory(s) that needs to be crawled.",
         )
         self.parser.add_argument(
             "--delete-from-fs",
@@ -277,7 +280,7 @@ class DeleteData(BaseParser):
 class Cli(SubCommandParser):
     """Class that constructs the Data Crawler Argument Parser."""
 
-    desc = "Update users project data"
+    desc = "Update users project data."
 
     def __init__(
         self,

--- a/src/freva/cli/utils.py
+++ b/src/freva/cli/utils.py
@@ -354,20 +354,20 @@ class BaseCompleter:
     def arg_to_dict(
         args: Optional[list[str]], append: bool = False
     ) -> dict[str, list[str]]:
-        """Convert a parsed arguments with key=value pairs to a dictionary.
+        """Convert a parsed arguments with ``key=value`` pairs to a dictionary.
 
         Parameters:
         ----------
         args:
             Collection of arguments that are converted to dict, the arguments
-            should be of form key=value
+            should be of form ``key=value``.
         append:
             If a key occurs twice convert first value to list and append second
             value to list, the default behaviour is updating the entry with
-            the second value
+            the second value.
         Returns:
         --------
-        dict: Dictionary representation of key=value pairs
+        dict: Dictionary representation of ``key=value`` pairs.
         """
         out_dict: dict[str, list[str]] = {}
         for arg in args or []:
@@ -434,18 +434,18 @@ class BaseCompleter:
             description="Get choices for command line arguments"
         )
         parser.add_argument(
-            "command", help="First command, freva, freva-histor etc", type=str
+            "command", help="First command, freva, freva-history etc.", type=str
         )
         parser.add_argument("--shell", help="Shell in use", default="bash", type=str)
         parser.add_argument(
             "--strip",
-            help="Do not print options starting with -",
+            help="Do not print options starting with - .",
             default=False,
             action="store_true",
         )
         parser.add_argument(
             "--flags-only",
-            help="Only print options starting with -",
+            help="Only print options starting with - .",
             default=False,
             action="store_true",
         )
@@ -478,7 +478,7 @@ def print_choices(arguments: list[str]) -> None:
     Parameters:
     -----------
     arguments:
-        List of command line arguments, that are evaluated by the choice printer
+        List of command line arguments, that are evaluated by the choice printer.
     """
     argv = [arg.strip() for arg in arguments if arg.strip()]
     comp = BaseCompleter.parse_choices(argv)

--- a/src/freva/utils.py
+++ b/src/freva/utils.py
@@ -186,7 +186,7 @@ class PluginStatus:
 
         Example
         -------
-        Read the output of the plugin
+        Read the output of the plugin:
 
         .. execute_code::
 
@@ -265,7 +265,7 @@ class PluginStatus:
 
         Raises
         ------
-        ValueError: If the plugin took longer than ``timeout`` seconds to finish
+        ValueError: If the plugin took longer than ``timeout`` seconds to finish.
 
         Example
         -------
@@ -309,7 +309,7 @@ class PluginStatus:
         ----------
         dtype: str
             The data type of the returned paths. This should be either
-            data or plot
+            data or plot.
         glob_pattern: str, default: *.nc
             Refine the output by filtering the returned files by the given
             glob pattern. By default only netCDF files ("*.nc") are added


### PR DESCRIPTION
this fix solves this bug. I added `GIF` to the `IMAGE_RESIZE_EXCEPTIONS = ["PDF", "HDF5", "GRIB", "GIF"]` so the files with this extension will be copied instead of resized.

E.g. `.mp4` files were copied because they were neither in that list nor they were recognised by `Image.registered_extensions()` 

everything else are minor typo/punctuation fixes.

To be merged after the history flag branch has been merged.