### PR TITLE
fix: mariadb 1000 group existed

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=solr:latest /var/solr/ /var/solr/
 COPY --from=condaforge/mambaforge:latest /opt/conda /opt/conda
 COPY . /tmp/evaluation_system
 RUN set -x && \
+  if groupdel -f ubuntu; then echo 'ubuntu group removed'; fi && \
   groupadd -r --gid  1000 freva && \
   groupadd -r --gid  8983 solr && \
   adduser --uid 1001 --gid 1000 --gecos "Default user" \


### PR DESCRIPTION
The ubuntu:noble base of MariaDB included a
1000 group id of "ubuntu" conflicting with the
freva group addition. Remove it if its there.