### PR TITLE
Do not show the path where the logger get emmited.

### DIFF
--- a/src/evaluation_system/misc/__init__.py
+++ b/src/evaluation_system/misc/__init__.py
@@ -8,8 +8,8 @@ from rich.logging import RichHandler
 
 logger_stream_handle = RichHandler(
     rich_tracebacks=True,
-    show_path=True,
-    console=Console(soft_wrap=True, stderr=True),
+    show_path=False,
+    console=Console(soft_wrap=False, stderr=True),
 )
 logger_stream_handle.setLevel(logging.INFO)
 logging.basicConfig(


### PR DESCRIPTION
Rich logger doesn't play nice in jupyter notebooks. Let's not display the paths.