### PR TITLE
verify the functionality of images

### DIFF
--- a/.docker/docker-entrypoint.sh
+++ b/.docker/docker-entrypoint.sh
@@ -4,16 +4,15 @@ if [ "$VERBOSE" == "yes" ];then
     set -xe
 fi
 source /usr/local/bin/docker-entrypoint.sh
-set -- mariadbd
 # call main bits of the mariadb entrypoint to have DB initialized
-docker_setup_env "$@"
-docker_create_db_directories "$@"
+docker_setup_env "mariadbd"
+docker_create_db_directories "mariadbd"
 # there's no database, so it needs to be initialized
 if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
-    docker_verify_minimum_env "$@"
-    docker_mariadb_init "$@"
+    docker_verify_minimum_env "mariadbd"
+    docker_mariadb_init "mariadbd"
 elif _check_if_upgrade_is_needed; then
-    docker_mariadb_upgrade "$@"
+    docker_mariadb_upgrade "mariadbd"
 fi
 mariadbd --user=${MARIADB_USER} --datadir=${MYSQL_DATA_DIR} --socket=/tmp/mysql.sock --console &
 until mariadb-admin ping --user="${MARIADB_USER}" --password="${MARIADB_PASSWORD}" --socket="/tmp/mysql.sock" --silent;
@@ -38,4 +37,4 @@ if [ "${IS_BINDER}" = "true" ];then
         freva plugin dummyplugin the_number=$i
     done
 fi
-exec "/opt/evaluation_system/bin/loadfreva.sh"
+exec "$@"


### PR DESCRIPTION
Hi @antarcticrainforest 

This is how the images commands and output look like. Please let me know if you have any concern regarding this

Freva Image result :

```bash
❯ docker run freva freva-plugin --list
2024-09-17 11:59:37+00:00 [Note] [Entrypoint]: Initializing database files
2024-09-17 11:59:38+00:00 [Note] [Entrypoint]: Database files initialized
2024-09-17 11:59:38+00:00 [Note] [Entrypoint]: Starting temporary server
2024-09-17 11:59:38+00:00 [Note] [Entrypoint]: Waiting for server startup
2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: Temporary server started.
2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: Creating database freva
2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: Creating user freva
2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: Giving user freva access to schema freva
2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: Securing system users (equivalent to running mysql_secure_installation)

2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: /opt/evaluation_system/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/create_tables.sql


2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: Stopping temporary server
2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: Temporary server stopped

2024-09-17 11:59:41+00:00 [Note] [Entrypoint]: MariaDB init process done. Ready for start up.

waiting for mariadb
freva T3st
mysqld is alive
neither jattach nor jstack in /opt/java/openjdk could be found, so no thread dumps are possible. Continuing.
Java 17 detected. Enabled workaround for SOLR-16463
Waiting up to 180 seconds to see Solr running on port 8983 [|]  
Started Solr server on port 8983 (pid=188). Happy searching!

Solr is up!
[11:59:47] ERROR    freva - ERROR - Could not read git version  repository.py:80
           ERROR    freva - ERROR - Error while reading git     repository.py:81
                    version:                                                    
                    /mnt/freva_plugins/dummy                                    
Dummy tool was run with: {'number': None, 'the_number': 1, 'something': 'test', 'other': 1.4, 'input': None, 'variable': 'tas'}
[11:59:48] ERROR    freva - ERROR - Could not read git version  repository.py:80
           ERROR    freva - ERROR - Error while reading git     repository.py:81
                    version:                                                    
                    /mnt/freva_plugins/dummy                                    
Dummy tool was run with: {'number': None, 'the_number': 2, 'something': 'test', 'other': 1.4, 'input': None, 'variable': 'tas'}
[11:59:48] ERROR    freva - ERROR - Could not read git version  repository.py:80
           ERROR    freva - ERROR - Error while reading git     repository.py:81
                    version:                                                    
                    /mnt/freva_plugins/dummy                                    
Dummy tool was run with: {'number': None, 'the_number': 3, 'something': 'test', 'other': 1.4, 'input': None, 'variable': 'tas'}
[11:59:49] ERROR    freva - ERROR - Could not read git version  repository.py:80
           ERROR    freva - ERROR - Error while reading git     repository.py:81
                    version:                                                    
                    /mnt/freva_plugins/dummy                                    
Dummy tool was run with: {'number': None, 'the_number': 4, 'something': 'test', 'other': 1.4, 'input': None, 'variable': 'tas'}
[11:59:49] ERROR    freva - ERROR - Could not read git version  repository.py:80
           ERROR    freva - ERROR - Error while reading git     repository.py:81
                    version:                                                    
                    /mnt/freva_plugins/dummy                                    
Dummy tool was run with: {'number': None, 'the_number': 5, 'something': 'test', 'other': 1.4, 'input': None, 'variable': 'tas'}
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Tool        ┃ Description                   ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Animator    │ Animate data on lon/lat grids │
│ DummyPlugin │ A dummy plugin                │
└─────────────┴───────────────────────────────┘
```

Freva-dev image result:

```bash
❯ docker run freva-dev bash -c "\
∙   until mariadb-admin ping --user=\"${MARIADB_USER}\" --password=\"${MARIADB_PASSWORD}\" --socket=\"/tmp/mysql.sock\" --silent; do \
∙     echo 'waiting for mariadb'; \
∙     sleep 1; \
∙   done && \
∙   echo 'mariaDB is running'"
2024-09-17 12:11:05+00:00 [Note] [Entrypoint]: Initializing database files
2024-09-17 12:11:06+00:00 [Note] [Entrypoint]: Database files initialized
2024-09-17 12:11:06+00:00 [Note] [Entrypoint]: Starting temporary server
2024-09-17 12:11:06+00:00 [Note] [Entrypoint]: Waiting for server startup
2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: Temporary server started.
2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: Creating database freva
2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: Creating user freva
2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: Giving user freva access to schema freva
2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: Securing system users (equivalent to running mysql_secure_installation)

2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: /opt/evaluation_system/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/create_tables.sql


2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: Stopping temporary server
2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: Temporary server stopped

2024-09-17 12:11:08+00:00 [Note] [Entrypoint]: MariaDB init process done. Ready for start up.

waiting for mariadb
freva T3st
mysqld is alive
neither jattach nor jstack in /opt/java/openjdk could be found, so no thread dumps are possible. Continuing.
Java 17 detected. Enabled workaround for SOLR-16463
Waiting up to 180 seconds to see Solr running on port 8983 [|]  
Started Solr server on port 8983 (pid=186). Happy searching!

mariaDB is running
```
