### PR TITLE
Fix mariadb image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ install:
 	python3 -m pip install .[test]
 
 test:
-	python3 -m pytest -vv --nbval --current-env $(PWD)/src/evaluation_system/tests
+	python3 -m pytest -s -vv --nbval --current-env $(PWD)/src/evaluation_system/tests
 
 test_coverage:
-	python3 -m pytest -vv \
+	python3 -m pytest -s -vv \
 		--nbval --current-env --cov=$(PWD)/src --cov-report=html:coverage_report \
 	    --junitxml report.xml --current-env --cov-report xml \
 		$(PWD)/src/evaluation_system/tests

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   db:
-    image: mariadb:11.3
+    image: mariadb:latest
     environment:
       MYSQL_USER: freva
       MYSQL_PASSWORD: T3st

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,12 @@ services:
       MYSQL_ROOT_PASSWORD: test_password_please_ignore
     ports:
       - "3306:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3      
     volumes:
       - ./compose/config/mysql/create_tables.sql:/docker-entrypoint-initdb.d/create_tables.sql:ro
   solr:


### PR DESCRIPTION
@grooverdan Thank you for the update. The issue with the Ubuntu user in the [Dockerfile](https://github.com/FREVA-CLINT/freva/blob/main/.docker/Dockerfile) has already been resolved. However, our main challenge lies with the [docker-compose](https://github.com/FREVA-CLINT/freva/blob/fix-mariadb-image/docker-compose.yaml#L4) file. When we revert from version 11.3 to the latest, we encounter the error: `Lost connection to MySQL server during query`. I believe this could be related to the latest MariaDB version, which might require us to design a custom entry point. Do you have any suggestions on how to address this?

Since the logs don't persist in GitHub Actions, I've shared them here. But, you can re-run the action to observe the issue firsthand.

```bash

│   122 │   │   │   raise ValueError(             │
                             │   123 │   │   │   │   "Error while accessing Co │
                             ╰─────────────────────────────────────────────────╯
                             ValueError: ('Bad databrowser request: %s',        
                             <HTTPError 400: 'Bad Request'>)                    
[10/15/24 07:18:52] DEBUG    Loading configuration file from:                   
                             /tmp/tmp2oe1q4aw/evaluation_system.conf            
                    DEBUG    Configuration loaded from                          
                             /tmp/tmp2oe1q4aw/evaluation_system.conf            
                    DEBUG    Loading configuration file from:                   
                             /tmp/tmp2oe1q4aw/evaluation_system.conf            
                    DEBUG    Configuration loaded from                          
                             /tmp/tmp2oe1q4aw/evaluation_system.conf            
                    DEBUG    http://localhost:8983/solr/admin/cores?action=STATU
                             S&core=files&wt=json                               
                    DEBUG    http://localhost:8983/solr/admin/cores?action=STATU
                             S&core=latest&wt=json                              
                    DEBUG    http://localhost:8983/solr/files/update/json?commit
                             =true                                              
                    DEBUG    http://localhost:8983/solr/latest/update/json?commi
                             t=true                                             
                    DEBUG    http://localhost:8983/solr/latest/update/json?commi
                             t=true                                             
                    DEBUG    http://localhost:8983/solr/files/update/json?commit
                             =true                                              
                    INFO     Sending last 5 entries                             
                    DEBUG    http://localhost:8983/solr/files/update/json?commit
                             =true                                              
                    DEBUG    http://localhost:8983/solr/latest/update/json?commi
                             t=true                                             
[10/15/24 07:18:53] DEBUG    {'variable': 'tauu', 'q': '*:*', 'fl': 'file',     
                             'sort': 'file desc'}                               
                    DEBUG    [('fq', 'variable:tauu'), ('q', '*:*'), ('fl',     
                             'file'), ('sort', 'file desc')]                    
                    DEBUG    {'variable': 'tauu', 'q': '*:*', 'fl': 'file',     
                             'sort': 'file desc'}                               
                    DEBUG    [('fq', 'variable:tauu'), ('q', '*:*'), ('fl',     
                             'file'), ('sort', 'file desc')]                    
                    DEBUG    http://localhost:8[983](https://github.com/FREVA-CLINT/freva/actions/runs/11341127126/job/31538810753#step:7:984)/solr/latest/select?facet=true
                             &rows=0&fq=variable%3Atauu&q=%2A%3A%2A&fl=file&sort
                             =file+desc&wt=json                                 
                    DEBUG    http://localhost:8983/solr/latest/select?start=0&ro
                             ws=1&fq=variable%3Atauu&q=%2A%3A%2A&fl=file&sort=fi
                             le+desc&wt=json                                    
                    DEBUG    {'variable': 'ua', 'q': '*:*', 'fl': 'file',       
                             'sort': 'file desc'}                               
                    DEBUG    [('fq', 'variable:ua'), ('q', '*:*'), ('fl',       
                             'file'), ('sort', 'file desc')]                    
                    DEBUG    {'variable': 'ua', 'q': '*:*', 'fl': 'file',       
                             'sort': 'file desc'}                               
                    DEBUG    [('fq', 'variable:ua'), ('q', '*:*'), ('fl',       
                             'file'), ('sort', 'file desc')]                    
                    DEBUG    http://localhost:8983/solr/latest/select?facet=true
                             &rows=0&fq=variable%3Aua&q=%2A%3A%2A&fl=file&sort=f
                             ile+desc&wt=json                                   
                    DEBUG    http://localhost:8983/solr/latest/select?start=0&ro
                             ws=1&fq=variable%3Aua&q=%2A%3A%2A&fl=file&sort=file
                             +desc&wt=json                                      
                    DEBUG    {'dataset': 'cmip5', 'q': '*:*', 'fl': 'file',     
                             'sort': 'file desc'}                               
                    DEBUG    [('fq', 'dataset:cmip5'), ('q', '*:*'), ('fl',     
                             'file'), ('sort', 'file desc')]                    
                    DEBUG    {'dataset': 'cmip5', 'q': '*:*', 'fl': 'file',     
                             'sort': 'file desc'}                               
                    DEBUG    [('fq', 'dataset:cmip5'), ('q', '*:*'), ('fl',     
                             'file'), ('sort', 'file desc')]                    
                    DEBUG    http://localhost:8983/solr/latest/select?facet=true
                             &rows=0&fq=dataset%3Acmip5&q=%2A%3A%2A&fl=file&sort
                             =file+desc&wt=json                                 
                    DEBUG    http://localhost:8983/solr/latest/select?start=0&ro
                             ws=3&fq=dataset%3Acmip5&q=%2A%3A%2A&fl=file&sort=fi
                             le+desc&wt=json                                    
                    DEBUG    http://localhost:8983/solr/latest/update/json?commi
                             t=true                                             
                    DEBUG    http://localhost:8983/solr/files/update/json?commit
                             =true                                              
                    INFO     Sending last 4 entries                             
                    DEBUG    http://localhost:8983/solr/files/update/json?commit
                             =true                                              
                    DEBUG    http://localhost:8983/solr/latest/update/json?commi
                             t=true                                             
                    DEBUG    http://localhost:8983/solr/files/update/json?commit
                             =true                                              
                    DEBUG    http://localhost:8983/solr/latest/update/json?commi
                             t=true                                             
                    INFO     history, limit=10, since=None, until=None,         
                             entry_ids=None                                     
                    INFO     history, limit=10, since=None, until=None,         
                             entry_ids=['2127']                                 
                    INFO     history, limit=10, since=None, until=None,         
                             entry_ids=[2127]                                   
                    INFO     history, limit=10, since=None, until=None,         
                             entry_ids=[2127.0]                                 
                    INFO     history, limit=10, since=None, until=None,         
                             entry_ids=['bla']                                  
                    INFO     history, limit=10, since=None, until=None,         
                             entry_ids=['0']                                    
[10/15/24 07:18:55] INFO     history, limit=10, since=None, until=None,         
                             entry_ids=None                                     
Process Process-73:
KeyboardInterrupt
[10/15/24 07:18:57] INFO     history, limit=10, since=None, until=None,         
                             entry_ids=None                                     
                    ERROR    (2013, 'Lost connection to MySQL server during     
                             query') - increase verbosity flags (-v) for more   
                             information                                        
                             ╭─────── Traceback (most recent call last) ───────╮
                             │ /usr/share/miniconda/envs/tests/lib/python3.12/ │
                             │ site-packages/MySQLdb/connections.py:261 in     │
                             │ query                                           │
                             │                                                 │
                             │   258 │   │   # Since _mysql releases GIL while │
                             │   259 │   │   if isinstance(query, bytearray):  │
                             │   260 │   │   │   query = bytes(query)          │
                             │ ❱ 261 │   │   _mysql.connection.query(self, que │
                             │   262 │                                         │
                             │   263 │   def _bytes_literal(self, bs):         │
                             │   264 │   │   assert isinstance(bs, (bytes, byt │
                             ╰─────────────────────────────────────────────────╯
                             OperationalError: (2013, 'Lost connection to MySQL 
                             server during query')                              
[10/15/24 07:18:58] ERROR    (2013, 'Lost connection to MySQL server during     
                             query') - increase verbosity flags (-v) for more   
                             information

```