### PR TITLE
use Pluginstatus for other users' history_ids

### DIFF
--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -5,12 +5,13 @@ What's new
    :maxdepth: 0
    :titlesonly:
 
-v2502.1.0
+v2504.0.0
 ~~~~~~~~~
 
 New Features
 ++++++++++++
-- Plugin SelectField can recieve multiple and custom user input values.
+- Plugin SelectField can receive multiple and custom user input values.
+- ``PluginStatus`` can access the status of ``job_ids`` of any user.
 
 
 v2502.0.1
@@ -22,7 +23,7 @@ Bug fixes
 
 Documentations
 ++++++++++++++
-- Added mulit-version queries.
+- Added multi-version queries.
 
 
 

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -5,6 +5,14 @@ What's new
    :maxdepth: 0
    :titlesonly:
 
+v2502.1.0
+~~~~~~~~~
+
+New Features
+++++++++++++
+- Plugin SelectField can recieve multiple and custom user input values.
+
+
 v2502.0.1
 ~~~~~~~~~
 

--- a/src/evaluation_system/__init__.py
+++ b/src/evaluation_system/__init__.py
@@ -36,6 +36,7 @@ import warnings
 warnings.filterwarnings(
     "always", category=PendingDeprecationWarning, module="evaluation_system.*"
 )
+warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 
 __version__ = "2502.0.1"

--- a/src/evaluation_system/__init__.py
+++ b/src/evaluation_system/__init__.py
@@ -39,7 +39,7 @@ warnings.filterwarnings(
 warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 
-__version__ = "2502.0.1"
+__version__ = "2502.1.0"
 
 if __name__ == "__main__":
     print(__version__)

--- a/src/evaluation_system/__init__.py
+++ b/src/evaluation_system/__init__.py
@@ -39,7 +39,7 @@ warnings.filterwarnings(
 warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 
-__version__ = "2502.1.0"
+__version__ = "2504.0.0"
 
 if __name__ == "__main__":
     print(__version__)

--- a/src/evaluation_system/api/parameters.py
+++ b/src/evaluation_system/api/parameters.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import re
-import sys
 import textwrap
 from collections import defaultdict
 from typing import Any, Optional, Type, Union, cast
@@ -169,8 +168,7 @@ class ParameterType(initOrder):
 
         if len(values) > self.max_items:
             raise ValidationError(
-                "Expected %s items at most, got %s"
-                % (self.max_items, len(values))
+                "Expected %s items at most, got %s" % (self.max_items, len(values))
             )
 
         if (
@@ -238,8 +236,7 @@ class ParameterType(initOrder):
                 elif value[0] == "[":
                     # assume is a json array:
                     return [
-                        self.base_type(v)
-                        for v in self._verified(json.loads(value))
+                        self.base_type(v) for v in self._verified(json.loads(value))
                     ]
                 else:
                     # this is a single string, but we expect multiple,
@@ -333,11 +330,7 @@ class ParameterDictionary(dict):
     def __init__(self, *parameters: ParameterType) -> None:
         """Instantiate ParameterDictionary with the given list of parameters."""
         super().__init__()
-        extra = (
-            config.get_section("scheduler_options")
-            .get("extra_options", "")
-            .strip()
-        )
+        extra = config.get_section("scheduler_options").get("extra_options", "").strip()
         if extra.lower() == "none":
             extra = ""
         extra_scheduler_options = String(
@@ -353,15 +346,12 @@ class ParameterDictionary(dict):
             # check name is unique
             if param.name in self._params:
                 raise ValueError(
-                    "Parameters name must be unique. Got second %s key."
-                    % param.name
+                    "Parameters name must be unique. Got second %s key." % param.name
                 )
             self._params[param.name] = param
             self[param.name] = param.default
         self.setdefault("extra_scheduler_options", extra)
-        self._params.setdefault(
-            "extra_scheduler_options", extra_scheduler_options
-        )
+        self._params.setdefault("extra_scheduler_options", extra_scheduler_options)
 
     def __str__(self):
         return "%s(%s)" % (
@@ -464,15 +454,12 @@ class ParameterDictionary(dict):
                         missing_values
                     )
                 if too_many_items:
-                    msg += (
-                        "Too many entries for these parameters: %s"
-                        % ", ".join(
-                            [
-                                "%s(max:%s, found:%s)"
-                                % (param, max, len(config_dict[param]))
-                                for param, max in too_many_items
-                            ]
-                        )
+                    msg += "Too many entries for these parameters: %s" % ", ".join(
+                        [
+                            "%s(max:%s, found:%s)"
+                            % (param, max, len(config_dict[param]))
+                            for param, max in too_many_items
+                        ]
                     )
                 raise ValidationError(msg)
             return dict(missing=missing, too_many_items=too_many_items)
@@ -534,9 +521,7 @@ class ParameterDictionary(dict):
             try:
                 parsed_values: Any = self._params[key].parse(value)
             except KeyError as error:
-                raise ValidationError(
-                    f"{key} is not a valid parameter"
-                ) from error
+                raise ValidationError(f"{key} is not a valid parameter") from error
             if isinstance(parsed_values, list):
                 if isinstance(param_config[key], list):
                     param_config[key] = param_config[key] + parsed_values
@@ -1033,9 +1018,7 @@ class Range(String):
                 del_list += self._parse_comma(part)
             return PrintableList(sorted([x for x in result if x not in del_list]))
         except AttributeError as err:
-            raise ValueError(
-                f"'{value}' is no recognized as a range value"
-            ) from err
+            raise ValueError(f"'{value}' is no recognized as a range value") from err
 
     def to_str(self, value: Any) -> str:
         """Conevert input value to string."""
@@ -1163,9 +1146,6 @@ class SelectField(ParameterType):
         self.options = options
         self.allow_user_input = allow_user_input
         self.multiple = multiple
-        if multiple:
-            self.max_items = sys.maxsize
-
         super().__init__(**kwargs)
 
     def _verified(self, orig_values: Union[str, list[str]]) -> list[str]:
@@ -1213,6 +1193,4 @@ class SelectField(ParameterType):
                 f'Multiple values are not allowed for "{self.name}". '
                 f"Only a single value is permitted."
             )
-        if len(values) > 1:
-            self.max_items = len(values)
         return cast(PrintableList, values) if self.multiple else values[0]

--- a/src/evaluation_system/api/parameters.py
+++ b/src/evaluation_system/api/parameters.py
@@ -169,7 +169,8 @@ class ParameterType(initOrder):
 
         if len(values) > self.max_items:
             raise ValidationError(
-                "Expected %s items at most, got %s" % (self.max_items, len(values))
+                "Expected %s items at most, got %s"
+                % (self.max_items, len(values))
             )
 
         if (
@@ -237,7 +238,8 @@ class ParameterType(initOrder):
                 elif value[0] == "[":
                     # assume is a json array:
                     return [
-                        self.base_type(v) for v in self._verified(json.loads(value))
+                        self.base_type(v)
+                        for v in self._verified(json.loads(value))
                     ]
                 else:
                     # this is a single string, but we expect multiple,
@@ -331,7 +333,11 @@ class ParameterDictionary(dict):
     def __init__(self, *parameters: ParameterType) -> None:
         """Instantiate ParameterDictionary with the given list of parameters."""
         super().__init__()
-        extra = config.get_section("scheduler_options").get("extra_options", "").strip()
+        extra = (
+            config.get_section("scheduler_options")
+            .get("extra_options", "")
+            .strip()
+        )
         if extra.lower() == "none":
             extra = ""
         extra_scheduler_options = String(
@@ -347,12 +353,15 @@ class ParameterDictionary(dict):
             # check name is unique
             if param.name in self._params:
                 raise ValueError(
-                    "Parameters name must be unique. Got second %s key." % param.name
+                    "Parameters name must be unique. Got second %s key."
+                    % param.name
                 )
             self._params[param.name] = param
             self[param.name] = param.default
         self.setdefault("extra_scheduler_options", extra)
-        self._params.setdefault("extra_scheduler_options", extra_scheduler_options)
+        self._params.setdefault(
+            "extra_scheduler_options", extra_scheduler_options
+        )
 
     def __str__(self):
         return "%s(%s)" % (
@@ -455,12 +464,15 @@ class ParameterDictionary(dict):
                         missing_values
                     )
                 if too_many_items:
-                    msg += "Too many entries for these parameters: %s" % ", ".join(
-                        [
-                            "%s(max:%s, found:%s)"
-                            % (param, max, len(config_dict[param]))
-                            for param, max in too_many_items
-                        ]
+                    msg += (
+                        "Too many entries for these parameters: %s"
+                        % ", ".join(
+                            [
+                                "%s(max:%s, found:%s)"
+                                % (param, max, len(config_dict[param]))
+                                for param, max in too_many_items
+                            ]
+                        )
                     )
                 raise ValidationError(msg)
             return dict(missing=missing, too_many_items=too_many_items)
@@ -522,7 +534,9 @@ class ParameterDictionary(dict):
             try:
                 parsed_values: Any = self._params[key].parse(value)
             except KeyError as error:
-                raise ValidationError(f"{key} is not a valid parameter") from error
+                raise ValidationError(
+                    f"{key} is not a valid parameter"
+                ) from error
             if isinstance(parsed_values, list):
                 if isinstance(param_config[key], list):
                     param_config[key] = param_config[key] + parsed_values
@@ -1019,7 +1033,9 @@ class Range(String):
                 del_list += self._parse_comma(part)
             return PrintableList(sorted([x for x in result if x not in del_list]))
         except AttributeError as err:
-            raise ValueError(f"'{value}' is no recognized as a range value") from err
+            raise ValueError(
+                f"'{value}' is no recognized as a range value"
+            ) from err
 
     def to_str(self, value: Any) -> str:
         """Conevert input value to string."""
@@ -1145,7 +1161,7 @@ class SelectField(ParameterType):
         **kwargs,
     ):
         self.options = options
-        self.custom = allow_user_input
+        self.allow_user_input = allow_user_input
         self.multiple = multiple
         if multiple:
             self.max_items = sys.maxsize
@@ -1163,7 +1179,7 @@ class SelectField(ParameterType):
             if val in self.options.values():
                 key = next(k for k, v in self.options.items() if v == val)
                 result.append(key)
-            elif self.custom:
+            elif self.allow_user_input:
                 result.append(val)
             else:
                 allowed_values = ", ".join(list(self.options.values()))

--- a/src/evaluation_system/api/parameters.py
+++ b/src/evaluation_system/api/parameters.py
@@ -17,11 +17,7 @@ from typing import Any, Optional, Type, Union, cast
 
 from evaluation_system.misc import config
 from evaluation_system.misc.exceptions import ValidationError, deprecated_method
-from evaluation_system.misc.utils import (
-    PrintableList,
-    find_similar_words,
-    initOrder,
-)
+from evaluation_system.misc.utils import PrintableList, find_similar_words, initOrder
 from evaluation_system.model.plugins.models import Parameter
 
 ParameterBaseType = Union[str, int, float, bool, PrintableList]

--- a/src/evaluation_system/tests/mocks/dummy.py
+++ b/src/evaluation_system/tests/mocks/dummy.py
@@ -11,6 +11,7 @@ from evaluation_system.api.parameters import (
     InputDirectory,
     Integer,
     ParameterDictionary,
+    SelectField,
     String,
 )
 from evaluation_system.api.plugin import PluginAbstract
@@ -38,7 +39,12 @@ class DummyPlugin(PluginAbstract):
         String(name="something", default="test"),
         Float(name="other", default=1.4),
         InputDirectory(name="input", help="An input file"),
-        String(name="variable", default="tas", help="An input variable"),
+        SelectField(
+            name="variable",
+            default="tas",
+            options={"tas": "tas", "pr": "pr"},
+            help="An input variable",
+        ),
     )
     _runs: list = []
     _template = "${number} - $something - $other"

--- a/src/evaluation_system/tests/mocks/dummyfolder.py
+++ b/src/evaluation_system/tests/mocks/dummyfolder.py
@@ -5,9 +5,6 @@ import time
 from pathlib import Path
 from subprocess import PIPE, run
 
-from netCDF4 import Dataset as nc
-from PIL import Image
-
 from evaluation_system.api.parameters import (
     Directory,
     Float,
@@ -19,6 +16,8 @@ from evaluation_system.api.parameters import (
 from evaluation_system.api.plugin import PluginAbstract
 from evaluation_system.model.db import UserDB
 from evaluation_system.model.user import User
+from netCDF4 import Dataset as nc
+from PIL import Image
 
 
 class DummyPluginFolders(PluginAbstract):

--- a/src/evaluation_system/tests/mocks/dummyfolder.py
+++ b/src/evaluation_system/tests/mocks/dummyfolder.py
@@ -5,6 +5,9 @@ import time
 from pathlib import Path
 from subprocess import PIPE, run
 
+from netCDF4 import Dataset as nc
+from PIL import Image
+
 from evaluation_system.api.parameters import (
     Directory,
     Float,
@@ -16,8 +19,6 @@ from evaluation_system.api.parameters import (
 from evaluation_system.api.plugin import PluginAbstract
 from evaluation_system.model.db import UserDB
 from evaluation_system.model.user import User
-from netCDF4 import Dataset as nc
-from PIL import Image
 
 
 class DummyPluginFolders(PluginAbstract):

--- a/src/evaluation_system/tests/parameters_test.py
+++ b/src/evaluation_system/tests/parameters_test.py
@@ -455,11 +455,7 @@ def test_validate_errors(dummy_env):
 
 
 def test_help(dummy_env):
-    from evaluation_system.api.parameters import (
-        Float,
-        Integer,
-        ParameterDictionary,
-    )
+    from evaluation_system.api.parameters import Float, Integer, ParameterDictionary
 
     p_dict = ParameterDictionary(
         Integer(name="answer", help="just some value", default=42, print_format="%sm"),

--- a/src/evaluation_system/tests/parameters_test.py
+++ b/src/evaluation_system/tests/parameters_test.py
@@ -33,7 +33,11 @@ def test_parameter_type(dummy_env):
     with pytest.raises(ValidationError):
         String(name="foo", max_items=0)
     s_type = String(
-        name="foo", default="foo;bar", mandatory=True, max_items=2, item_separator=";"
+        name="foo",
+        default="foo;bar",
+        mandatory=True,
+        max_items=2,
+        item_separator=";",
     )
     assert s_type.to_str("foo;bar") == "foo;bar"
     assert s_type.to_str(["foo", "bar"]) == "foo;bar"
@@ -59,7 +63,11 @@ def test_parsing(dummy_env):
     )
 
     test_cases = [
-        (String(), [("asd", "asd"), (None, "None"), (1, "1"), (True, "True")], []),
+        (
+            String(),
+            [("asd", "asd"), (None, "None"), (1, "1"), (True, "True")],
+            [],
+        ),
         (
             String(regex="^x.*$"),
             [("xasd", "xasd")],
@@ -125,10 +133,13 @@ def test_parsing(dummy_env):
         ),
         (
             SelectField(
-                options={"option1": "value1", "another_option": "Some other value"}
+                options={
+                    "option1": "value1",
+                    "another_option": "Some other value",
+                }
             ),
             [("value1", "option1"), ("Some other value", "another_option")],
-            [("bad value", "")],
+            ["bad value"],
         ),
         (SolrField(facet="variable"), [("tas", "tas"), ("pr", "pr")], []),
         (InputDirectory(), [("/home/user", "/home/user")], []),
@@ -143,6 +154,7 @@ def test_parsing(dummy_env):
                 assert type(parsed_value) == case_type.base_type
             assert parsed_value == result
         for unparsable in negative_cases:
+            print(unparsable)
             try:
                 with pytest.raises(TypeError):
                     case_type.parse(unparsable)
@@ -155,6 +167,40 @@ def test_parsing(dummy_env):
                         case_type.parse(unparsable)
 
 
+def test_select_field(dummy_env):
+    """Test the SelectField parameter."""
+
+    from evaluation_system.api.parameters import SelectField, ValidationError
+
+    param1 = SelectField(
+        options={"option1": "value1", "another_option": "Some other value"}
+    )
+    assert param1.parse(["value1"]) == "option1"
+    assert param1.parse("Some other value") == "another_option"
+    with pytest.raises(ValidationError):
+        param1.parse("foo")
+    with pytest.raises(ValidationError):
+        param1.parse(["value1", "Some other value"])
+    param2 = SelectField(
+        options={"option1": "value1", "another_option": "Some other value"},
+        multiple=True,
+    )
+    assert len(param2.parse(["value1", "Some other value"])) == 2
+    with pytest.raises(ValidationError):
+        param2.parse(["foo"])
+    param3 = SelectField(
+        options={"option1": "value1", "another_option": "Some other value"},
+        allow_user_input=True,
+    )
+    assert param3.parse(["foo"]) == "foo"
+    param4 = SelectField(
+        options={"option1": "value1", "another_option": "Some other value"},
+        allow_user_input=True,
+        multiple=True,
+    )
+    assert isinstance(param4.parse(["foo"]), list)
+
+
 def test_parameters_dictionary(dummy_env):
     from evaluation_system.api.parameters import (
         ParameterDictionary,
@@ -164,7 +210,10 @@ def test_parameters_dictionary(dummy_env):
 
     p1 = String(name="a_param1", default="default default 1")
     p2 = String(
-        name="a_param2", default="default default 2", max_items=3, item_separator=":"
+        name="a_param2",
+        default="default default 2",
+        max_items=3,
+        item_separator=":",
     )
     assert p2.parse("a:b:C") == ["a", "b", "C"]
     with pytest.raises(ValueError):
@@ -302,7 +351,9 @@ def test_complete(dummy_env):
     )
 
     p_dict = ParameterDictionary(
-        Integer(name="int"), File(name="file", default="/tmp/file1"), Date(name="date")
+        Integer(name="int"),
+        File(name="file", default="/tmp/file1"),
+        Date(name="date"),
     )
     conf = dict(int=1)
     p_dict._complete(conf)
@@ -315,7 +366,10 @@ def test_complete(dummy_env):
         "file": "/tmp/file1",
     }
 
-    assert p_dict._complete() == {"extra_scheduler_options": "", "file": "/tmp/file1"}
+    assert p_dict._complete() == {
+        "extra_scheduler_options": "",
+        "file": "/tmp/file1",
+    }
     assert p_dict._complete(add_missing_defaults=True) == {
         "int": None,
         "date": None,
@@ -402,7 +456,11 @@ def test_validate_errors(dummy_env):
 
 
 def test_help(dummy_env):
-    from evaluation_system.api.parameters import Float, Integer, ParameterDictionary
+    from evaluation_system.api.parameters import (
+        Float,
+        Integer,
+        ParameterDictionary,
+    )
 
     p_dict = ParameterDictionary(
         Integer(name="answer", help="just some value", default=42, print_format="%sm"),

--- a/src/evaluation_system/tests/parameters_test.py
+++ b/src/evaluation_system/tests/parameters_test.py
@@ -154,7 +154,6 @@ def test_parsing(dummy_env):
                 assert type(parsed_value) == case_type.base_type
             assert parsed_value == result
         for unparsable in negative_cases:
-            print(unparsable)
             try:
                 with pytest.raises(TypeError):
                     case_type.parse(unparsable)

--- a/src/freva/utils.py
+++ b/src/freva/utils.py
@@ -164,7 +164,6 @@ class PluginStatus:
 
     def __init__(self, history_id: int) -> None:
         self._id: int = history_id
-        
 
     def __repr__(self) -> str:
         return (
@@ -179,9 +178,7 @@ class PluginStatus:
         try:
             hist = cast(
                 List[Dict[str, Any]],
-                freva.history(
-                    entry_ids=self._id, return_results=True, user_name="*"
-                ),
+                freva.history(entry_ids=self._id, return_results=True, user_name="*"),
             )[0]
         except IndexError:
             logger.setLevel(log_level)

--- a/src/freva/utils.py
+++ b/src/freva/utils.py
@@ -159,15 +159,12 @@ class PluginStatus:
         res = freva.PluginStatus(hist["id"])
         print(res.status)
 
-    You can consult other users' runs status by setting the
-    ``user_name=<user_id>`` parameter (``user_name="all"`` for any). Note
-    that you will not be able to fully interact with the status of others'
-    plugin runs (e.g. ``res.kill()``).
+    Note: You won't be able to kill running jobs associated to history id's from other users.
     """
 
-    def __init__(self, history_id: int, user_name=None) -> None:
+    def __init__(self, history_id: int) -> None:
         self._id: int = history_id
-        self._user_name: Optional[str] = user_name
+        
 
     def __repr__(self) -> str:
         return (
@@ -183,7 +180,7 @@ class PluginStatus:
             hist = cast(
                 List[Dict[str, Any]],
                 freva.history(
-                    entry_ids=self._id, return_results=True, user_name=self._user_name
+                    entry_ids=self._id, return_results=True, user_name="*"
                 ),
             )[0]
         except IndexError:

--- a/src/freva/utils.py
+++ b/src/freva/utils.py
@@ -158,10 +158,16 @@ class PluginStatus:
         hist = freva.history(plugin="dummypluginfolders", limit=1)[:-1]
         res = freva.PluginStatus(hist["id"])
         print(res.status)
+
+    You can consult other users' runs status by setting the
+    ``user_name=<user_id>`` parameter (``user_name="all"`` for any). Note
+    that you will not be able to fully interact with the status of others'
+    plugin runs (e.g. ``res.kill()``).
     """
 
-    def __init__(self, history_id: int) -> None:
+    def __init__(self, history_id: int, user_name=None) -> None:
         self._id: int = history_id
+        self._user_name: Optional[str] = user_name
 
     def __repr__(self) -> str:
         return (
@@ -176,7 +182,9 @@ class PluginStatus:
         try:
             hist = cast(
                 List[Dict[str, Any]],
-                freva.history(entry_ids=self._id, return_results=True),
+                freva.history(
+                    entry_ids=self._id, return_results=True, user_name=self._user_name
+                ),
             )[0]
         except IndexError:
             logger.setLevel(log_level)


### PR DESCRIPTION
suggestion to allow `PluginStatus()` to check the status' of other users' plugin runs. Request ffrom a user,  Issue https://github.com/FREVA-CLINT/freva/issues/234.

I am not that sure that it actually makes total sense to do that with PluginStatus, as I understand this class as focused on checking own status. But it might be useful if, for some reason, someone is running multi-user workflow and needs to e.g. wait for some other's run etc. 

[The changes are minimal](https://github.com/FREVA-CLINT/freva/blob/pluginstatus_other-users/src/freva/utils.py#L168). But is entirelly reasonable that you do not consider this as a good practice.
